### PR TITLE
Initial disconnected support.

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -58,6 +58,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+
       - name: Login to Quay
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
@@ -65,8 +66,21 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-      - name: Build, bundle, and push
-        run: |
-          pip3 install --user --upgrade setuptools wheel pip
-          develop/operate.sh --push-images --bundle --extra-tag=latest --verbose --formatter
-        if: github.ref == 'refs/heads/main'
+
+      - name: Install pip pre-reqs
+        run: pip3 install --user --upgrade setuptools wheel pip
+
+      - name: Generate bundle
+        run: develop/operate.sh --bundle-generate --extra-tag=latest --verbose --formatter
+
+      - name: Process bundle for disconnected support
+        uses: adamgoossens/github-actions/disconected-csv@main
+        with:
+          CSV_FILE: bundle/manifests/nexus-operator.clusterserviceversion.yaml
+          TAGS_TO_DIGESTS: 1
+
+      - name: Build and push operator image
+        run: develop/operate.sh --push-images --push-only --extra-tag=latest --verbose --formatter --img ${{secrets.IMAGE_REPOSITORY}}
+
+      - name: Build and push bundle image
+        run: develop/operate.sh --bundle-publish --verbose --formatter --extra-tag=latest -- img ${{secrets.IMAGE_REPOSITORY}}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,12 @@ spec:
         - "--leader-election-id=nexus-operator"
         image: controller:latest
         env:
+        - name: RELATED_IMAGE_NEXUS_UBI
+          value: registry.access.redhat.com/ubi8/ubi-minimal:latest
+        - name: RELATED_IMAGE_OAUTH_PROXY
+          value: docker.io/openshift/oauth-proxy:latest
+        - name: RELATED_IMAGE_NEXUS_SERVER
+          value: docker.io/sonatype/nexus3:latest
         - name: ANSIBLE_GATHERING
           value: explicit
         - name: WATCH_NAMESPACE

--- a/molecule/default/tasks/nexus_test.yml
+++ b/molecule/default/tasks/nexus_test.yml
@@ -5,7 +5,7 @@
     namespace: '{{ namespace }}'
     definition: "{{ lookup('template', '/'.join([samples_dir, cr_file])) | from_yaml }}"
     wait: yes
-    wait_timeout: 600
+    wait_timeout: 300
     wait_condition:
       type: Running
       reason: Successful

--- a/playbooks/nexus-operator.yml
+++ b/playbooks/nexus-operator.yml
@@ -12,6 +12,10 @@
     include_role:
       name: ./roles/nexus-ocp
     vars:
+      _nexus_server_imageref: "{{ lookup('env', 'RELATED_IMAGE_NEXUS_SERVER') }}"
+      _nexus_ubi_imageref: "{{ lookup('env', 'RELATED_IMAGE_NEXUS_UBI') }}"
+      _nexus_oauth_proxy_imageref: "{{ lookup('env', 'RELATED_IMAGE_OAUTH_PROXY') }}"
+
       _nexus_namespace: "{{ ansible_operator_meta.namespace }}"
       _nexus_name: "{{ nexus_service_name | default(ansible_operator_meta.name) }}"
 

--- a/roles/nexus-ocp/templates/deployment.yml.j2
+++ b/roles/nexus-ocp/templates/deployment.yml.j2
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "{{ _nexus_name }}"
       initContainers:
       - name: init
-        image: registry.access.redhat.com/ubi8/ubi-minimal
+        image: "{{ _nexus_ubi_imageref }}"
         command:
           - bash
           - -c
@@ -32,7 +32,7 @@ spec:
       containers:
 {% if _nexus_oauth|bool %}
       - name: oauth-proxy
-        image: 'openshift/oauth-proxy:latest'
+        image: "{{ _nexus_oauth_proxy_imageref }}"
         args:
           - '--https-address='
           - '--http-address=:4180'
@@ -50,7 +50,7 @@ spec:
         imagePullPolicy: {{ _nexus_image_pull_policy }}
 {% endif %}
       - name: nexus-server
-        image: "{{ _nexus_image }}:{{ _nexus_image_tag }}"
+        image: "{{ _nexus_server_imageref }}"
         imagePullPolicy: {{ _nexus_image_pull_policy }}
         ports:
         - containerPort: 8081


### PR DESCRIPTION
* Provide image references through parameter injection. In this case,
  via environment variables set on the Operator image.
* Customise operate.sh to separate bundle generation from bundle build.
  We need this to amend the bundle manifest for relatedImages and
  tags-to-digests before building the bundle.
* Refactor out IMG into a GitHub secret, so we can override this
  without needing to change operate.conf (e.g. for testing in forked
  repos).